### PR TITLE
Bugfix#19618 open needed ports for ips

### DIFF
--- a/conf
+++ b/conf
@@ -1,2 +1,0 @@
-Chef::Log.error "\n\n\n\n\nis_manager #{is_manager?}\nsync_ip #{sync_ip}\nip_addr #{ip_addr}\n\n\n\n"
-


### PR DESCRIPTION
## Related issue in RedMine

[https://redmine.redborder.lan/issues/19618](https://redmine.redborder.lan/issues/19618)

## Description / Motivation

If you try to install an IPS (manager mode) in a manager with 2 network interfaces (sync/management), the kafka port (9092) isn't open, so there isn't any rb_event data.

## Detail

Added a execute block that checks if the firewalld runtime rules are different with the firewalld permanent rules. If these are different means that a rule has been added/deleted, so the service needs to be reloaded.